### PR TITLE
v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# eggd_bcl2fastq
+<!-- dx-header -->
+# bcl2fastq v2.20 (DNAnexus Platform App)
+
+Dx wrapper to run the bcl2fastq demultiplexing tool
+
+This is the source code for an app that runs on the DNAnexus Platform.
+
+<!-- Insert a description of your app here -->
+## What does this app do?
+Takes in the tar.gz packets of data uploaded from the NovaSeq machine as sequencing data was generated. Untars the files to reconstruct the NovaSeq output directory structure and demultiplexes the base call files to paired fastq.tar.gz for samples in the SampleSheet.csv based on the barcode sequences.
+
+## What are typical use cases for this app?
+This app may be executed as a standalone app or as part of an analysis pipeline.
+Used as the first step when sequencing data is streamed from the sequencer to DNAnexus before bioinformatics analysis can begin.
+
+## What data are required for this app to run?
+This app requires
+* SampleSheet.csv
+* upload sentinel record
+* array of tar.gz containing the output packets from the sequencer
+* destination project name
+
+Optional input parameters:
+* Run information
+* lane splitting - defaults to FALSE
+* advanced options
+
+## What does this app output?
+* samplesheet.csv with a PASS/FAIL column
+* a folder of fastq files
+
+## Dependencies
+The app includes a tar.gz of the executable bcl2fast Docker image.
+
+### This app was made by East GLH

--- a/dxapp.json
+++ b/dxapp.json
@@ -1,0 +1,145 @@
+{
+    "name": "bcl2fastq220",
+    "title": "BCL to FASTQ v2.20",
+    "summary": "Converts Illumina data from BCL to FASTQ using bcl2fastq2.20 or higher, demultiplexing barcoded samples, for use with NextSeq, HiSeq, NovaSeq",
+    "tags": ["Read Mapping"],
+    "dxapi": "1.0.0",
+    "inputSpec": [
+      {
+        "name": "upload_sentinel_record",
+        "label": "Incremental upload sentinel record",
+        "help": "The sentinel record produced by the the incremental_upload.sh script. When this record is closed it indicates that the upload is complete and bcl2fastq can begin.",
+        "class": "record",
+        "optional": true
+      },
+      {
+        "name": "run_archive",
+        "label": "Archive of top level run folder",
+        "help": "One archived file containing the top level output from the run. This archive should contain RunInfo.xml and be named the same as the original file.",
+        "class": "array:file",
+        "patterns": ["*.rar", "*.zip", "*.tar.gz", "*.tgz"],
+        "optional": true
+      },
+      {
+        "name": "sample_sheet",
+        "label": "Sample sheet",
+        "help": "The sample sheet file in CSV format.",
+        "class": "file",
+        "patterns": ["*.csv"],
+        "optional": true
+      },
+      {
+        "name": "no_lane_splitting",
+        "label": "No Lane Splitting",
+        "help": "Turns on the --no-lane-splitting option which will combine all lanes into a single fastq for each sample",
+        "class": "boolean",
+        "default": true
+      },
+      {
+        "name": "advanced_opts",
+        "label": "Advanced options",
+        "help": "Additional command-line options to be passed verbatim to the invocation of bcl2fastq.",
+        "class": "string",
+        "optional": true,
+        "default": "-l NONE",
+        "group": "Advanced"
+      },
+      {
+        "name": "dest_project",
+        "label": "Destination project",
+        "help": "Project where failed samplesheet are saved.",
+        "class": "string",
+        "default": ""
+      },
+      {
+        "name": "info",
+        "label": "Run information",
+        "help": "Information about the current Run",
+        "class": "string",
+        "default": ""
+      }
+    ],
+    "outputSpec": [
+       {
+        "name": "out_info",
+        "label": "Run information",
+        "help": "Information about the current Run",
+        "class": "string"
+      },
+      {
+        "name": "reads",
+        "label": "Left mates of samples",
+        "help": "An array of FASTQ files of left mates (one per sample)",
+        "class": "array:file",
+        "patterns": ["*.fastq.gz"]
+      },
+      {
+        "name": "reads2",
+        "label": "Right mates of samples",
+        "help": "An array of FASTQ files of right mates (one per sample)",
+        "class": "array:file",
+        "patterns": ["*.fastq.gz"],
+        "optional": true
+      },
+      {
+        "name": "stats",
+        "label": "Statistics files",
+        "help": "An array of XML and HTML files with run statistics",
+        "class": "array:file",
+        "patterns": ["*.xml", "*.html"]
+      },
+      {
+        "name": "fastq_summaries",
+        "label": "Fastq summaries",
+        "class": "array:file",
+        "patterns": ["FastqSummary*.txt"]
+      },
+      {
+        "name": "demux_summaries",
+        "label": "Demultiplex summaries",
+        "class": "array:file",
+        "patterns": ["DemuxSummary*.txt"]
+      },
+      {
+        "name": "stats_record",
+        "label": "Stats record",
+        "class": "record"
+      },
+      {
+        "name": "new_sample_sheet",
+        "label": "Updated sample sheet",
+        "help": "The updaded sample sheet file in CSV format, with an extra column (PASS/FAIL) with the file size if higher than the minimum required. ",
+        "class": "file",
+        "patterns": ["*.csv"]
+      }
+    ],
+    "runSpec": {
+      "file": "src/code.sh",
+      "release": "20.04",
+      "version": "0",
+      "interpreter": "bash",
+      "distribution": "Ubuntu"
+    },
+    "access": {
+      "project": "UPLOAD"
+    },
+    "details": {
+      "upstreamAuthor": "Illumina",
+      "upstreamVersion": "2.20",
+      "upstreamLicenses": ["-"],
+      "citations": ["-"],
+      "whatsNew": "* 0.0.1: New app for converting bcl to fastq with bcl2fastq2.20",
+      "upstreamUrl": "https://support.illumina.com/content/dam/illumina-support/documents/documentation/software_documentation/bcl2fastq/bcl2fastq2_guide_15051736_v2.pdf"
+    },
+    "ignoreReuse": false,
+    "regionalOptions": {
+      "aws:eu-central-1": {
+        "systemRequirements": {
+          "*": {
+            "instanceType": "mem1_ssd2_v2_x36"
+          }
+        }
+      }
+    }
+  }
+  

--- a/dxapp.json
+++ b/dxapp.json
@@ -1,6 +1,6 @@
 {
-  "name": "bcl2fastq_v2.20_dev3",
-  "title": "BCL to FASTQ v2.20.2",
+  "name": "bcl2fastq_v2.20_dev",
+  "title": "BCL to FASTQ v2.20",
   "summary": "Converts Illumina data from BCL to FASTQ using bcl2fastq v2.20 or higher demultiplexing barcoded samples, for use with NextSeq, HiSeq, NovaSeq",
   "tags": ["Read Mapping"],
   "dxapi": "1.0.0",

--- a/dxapp.json
+++ b/dxapp.json
@@ -40,15 +40,8 @@
   ],
   "outputSpec": [
     {
-      "name": "fastqs",
-      "label": "Fastq files of samples",
-      "help": "An array of FASTQ files of both left and right mates (one pair per sample)",
-      "class": "array:file",
-      "patterns": ["*.fastq.gz"]
-    },
-    {
-      "name": "stats",
-      "label": "Statistics files",
+      "name": "output",
+      "label": "All files (except bcls) from the sequencer after demultiplexing",
       "help": "An array of files with run statistics",
       "class": "array:file"
     }

--- a/dxapp.json
+++ b/dxapp.json
@@ -1,7 +1,7 @@
 {
-  "name": "bcl2fastq_v2.20_dev",
+  "name": "bcl2fastq2.20_v1.0.0",
   "title": "BCL to FASTQ v2.20",
-  "summary": "Converts Illumina data from BCL to FASTQ using bcl2fastq v2.20 or higher demultiplexing barcoded samples, for use with NextSeq, HiSeq, NovaSeq",
+  "summary": "Converts Illumina data from BCL to FASTQ using bcl2fastq v2.20 demultiplexing barcoded samples, for use with NextSeq, HiSeq, NovaSeq",
   "tags": ["Read Mapping"],
   "dxapi": "1.0.0",
   "inputSpec": [

--- a/dxapp.json
+++ b/dxapp.json
@@ -1,145 +1,92 @@
 {
-    "name": "bcl2fastq220",
-    "title": "BCL to FASTQ v2.20",
-    "summary": "Converts Illumina data from BCL to FASTQ using bcl2fastq2.20 or higher, demultiplexing barcoded samples, for use with NextSeq, HiSeq, NovaSeq",
-    "tags": ["Read Mapping"],
-    "dxapi": "1.0.0",
-    "inputSpec": [
+  "name": "bcl2fastq_v2.20_dev3",
+  "title": "BCL to FASTQ v2.20.2",
+  "summary": "Converts Illumina data from BCL to FASTQ using bcl2fastq v2.20 or higher demultiplexing barcoded samples, for use with NextSeq, HiSeq, NovaSeq",
+  "tags": ["Read Mapping"],
+  "dxapi": "1.0.0",
+  "inputSpec": [
+    {
+      "name": "upload_sentinel_record",
+      "label": "Incremental upload sentinel record",
+      "help": "The sentinel record produced by the the incremental_upload.sh script. When this record is closed it indicates that the upload is complete and bcl2fastq can begin.",
+      "class": "record",
+      "optional": true
+    },
+    {
+      "name": "run_archive",
+      "label": "Archive of top level run folder",
+      "help": "One archived file containing the top level output from the run. This archive should contain RunInfo.xml and be named the same as the original file.",
+      "class": "array:file",
+      "patterns": ["*.rar", "*.zip", "*.tar.gz", "*.tgz"],
+      "optional": true
+    },
+    {
+      "name": "sample_sheet",
+      "label": "Sample sheet",
+      "help": "The sample sheet file in CSV format.",
+      "class": "file",
+      "patterns": ["*.csv"],
+      "optional": true
+    },
+    {
+      "name": "advanced_opts",
+      "label": "Advanced options",
+      "help": "Additional command-line options to be passed verbatim to the invocation of bcl2fastq.",
+      "class": "string",
+      "optional": true,
+      "default": "-l NONE",
+      "group": "Advanced"
+    }
+  ],
+  "outputSpec": [
+    {
+      "name": "fastqs",
+      "label": "Fastq files of samples",
+      "help": "An array of FASTQ files of both left and right mates (one pair per sample)",
+      "class": "array:file",
+      "patterns": ["*.fastq.gz"]
+    },
+    {
+      "name": "stats",
+      "label": "Statistics files",
+      "help": "An array of files with run statistics",
+      "class": "array:file"
+    }
+  ],
+  "runSpec": {
+    "file": "src/code.sh",
+    "release": "16.04",
+    "version": "0",
+    "interpreter": "bash",
+    "distribution": "Ubuntu",
+    "assetDepends": [
       {
-        "name": "upload_sentinel_record",
-        "label": "Incremental upload sentinel record",
-        "help": "The sentinel record produced by the the incremental_upload.sh script. When this record is closed it indicates that the upload is complete and bcl2fastq can begin.",
-        "class": "record",
-        "optional": true
-      },
-      {
-        "name": "run_archive",
-        "label": "Archive of top level run folder",
-        "help": "One archived file containing the top level output from the run. This archive should contain RunInfo.xml and be named the same as the original file.",
-        "class": "array:file",
-        "patterns": ["*.rar", "*.zip", "*.tar.gz", "*.tgz"],
-        "optional": true
-      },
-      {
-        "name": "sample_sheet",
-        "label": "Sample sheet",
-        "help": "The sample sheet file in CSV format.",
-        "class": "file",
-        "patterns": ["*.csv"],
-        "optional": true
-      },
-      {
-        "name": "no_lane_splitting",
-        "label": "No Lane Splitting",
-        "help": "Turns on the --no-lane-splitting option which will combine all lanes into a single fastq for each sample",
-        "class": "boolean",
-        "default": true
-      },
-      {
-        "name": "advanced_opts",
-        "label": "Advanced options",
-        "help": "Additional command-line options to be passed verbatim to the invocation of bcl2fastq.",
-        "class": "string",
-        "optional": true,
-        "default": "-l NONE",
-        "group": "Advanced"
-      },
-      {
-        "name": "dest_project",
-        "label": "Destination project",
-        "help": "Project where failed samplesheet are saved.",
-        "class": "string",
-        "default": ""
-      },
-      {
-        "name": "info",
-        "label": "Run information",
-        "help": "Information about the current Run",
-        "class": "string",
-        "default": ""
+        "name": "bcl2fastq",
+        "version": "2.20",
+        "project": "project-Fkb6Gkj433GVVvj73J7x8KbV",
+        "folder": "/assets/bcl2fastq"
       }
-    ],
-    "outputSpec": [
-       {
-        "name": "out_info",
-        "label": "Run information",
-        "help": "Information about the current Run",
-        "class": "string"
-      },
-      {
-        "name": "reads",
-        "label": "Left mates of samples",
-        "help": "An array of FASTQ files of left mates (one per sample)",
-        "class": "array:file",
-        "patterns": ["*.fastq.gz"]
-      },
-      {
-        "name": "reads2",
-        "label": "Right mates of samples",
-        "help": "An array of FASTQ files of right mates (one per sample)",
-        "class": "array:file",
-        "patterns": ["*.fastq.gz"],
-        "optional": true
-      },
-      {
-        "name": "stats",
-        "label": "Statistics files",
-        "help": "An array of XML and HTML files with run statistics",
-        "class": "array:file",
-        "patterns": ["*.xml", "*.html"]
-      },
-      {
-        "name": "fastq_summaries",
-        "label": "Fastq summaries",
-        "class": "array:file",
-        "patterns": ["FastqSummary*.txt"]
-      },
-      {
-        "name": "demux_summaries",
-        "label": "Demultiplex summaries",
-        "class": "array:file",
-        "patterns": ["DemuxSummary*.txt"]
-      },
-      {
-        "name": "stats_record",
-        "label": "Stats record",
-        "class": "record"
-      },
-      {
-        "name": "new_sample_sheet",
-        "label": "Updated sample sheet",
-        "help": "The updaded sample sheet file in CSV format, with an extra column (PASS/FAIL) with the file size if higher than the minimum required. ",
-        "class": "file",
-        "patterns": ["*.csv"]
-      }
-    ],
-    "runSpec": {
-      "file": "src/code.sh",
-      "release": "20.04",
-      "version": "0",
-      "interpreter": "bash",
-      "distribution": "Ubuntu"
-    },
-    "access": {
-      "project": "UPLOAD"
-    },
-    "details": {
-      "upstreamAuthor": "Illumina",
-      "upstreamVersion": "2.20",
-      "upstreamLicenses": ["-"],
-      "citations": ["-"],
-      "whatsNew": "* 0.0.1: New app for converting bcl to fastq with bcl2fastq2.20",
-      "upstreamUrl": "https://support.illumina.com/content/dam/illumina-support/documents/documentation/software_documentation/bcl2fastq/bcl2fastq2_guide_15051736_v2.pdf"
-    },
-    "ignoreReuse": false,
-    "regionalOptions": {
-      "aws:eu-central-1": {
-        "systemRequirements": {
-          "*": {
-            "instanceType": "mem1_ssd2_v2_x36"
-          }
+    ]
+  },
+  "access": {
+    "project": "UPLOAD"
+  },
+  "details": {
+    "upstreamAuthor": "Illumina",
+    "upstreamVersion": "2.20",
+    "upstreamLicenses": ["-"],
+    "citations": ["-"],
+    "whatsNew": "* 0.0.1: New app for converting bcl to fastq with bcl2fastq2.20",
+    "upstreamUrl": "https://support.illumina.com/content/dam/illumina-support/documents/documentation/software_documentation/bcl2fastq/bcl2fastq2_guide_15051736_v2.pdf"
+  },
+  "ignoreReuse": false,
+  "regionalOptions": {
+    "aws:eu-central-1": {
+      "systemRequirements": {
+        "*": {
+          "instanceType": "mem1_ssd2_v2_x36"
         }
       }
     }
   }
-  
+}

--- a/src/code.sh
+++ b/src/code.sh
@@ -4,297 +4,219 @@
 # and to output each line as it is executed -- useful for debugging
 set -e -x -o pipefail
 
-# check if lane splitting is turned on
-if [ "${no_lane_splitting}" == "true" ]
-then
-    args+=("--no-lane-splitting")
-fi
+main() {
 
- # either a run archive or a sentinel record must be provided as an input
+  echo "Step 1: download input tars and unpack them"
+  # either a run archive or a sentinel record must be provided as an input
   if [ -n "${run_archive}" ]; then
-
     for i in ${!run_archive_name[@]}; do
+      # check format and decompress
+      name="${run_archive_name[${i}]}"
 
-        # format check and uncompress
-        name="${run_archive_name[${i}]}"
-        if [ "${name}" == *.rar ]; then
+      if [[ "${name}" == *.tar.gz ]] || [[ "${name}" == *.tgz ]]; then
+        dx cat "${run_archive[${i}]}" | tar zxf - --no-same-owner
 
-          dx download "${run_archive[${i}]}" -o "${name}"
-          unrar x "${name}"
+      elif [ "${name}" == *.zip ]; then
+        dx download "${run_archive[$i]}" -o "${name}"
+        unzip "${name}"
 
-        elif [ "${name}" == *.zip ]; then
+      elif [ "${name}" == *.rar ]; then
+        dx download "${run_archive[${i}]}" -o "${name}"
+        unrar x "${name}"
 
-          dx download "${run_archive[$i]}" -o "${name}"
-          unzip "${name}"
+      else
+        dx-jobutil-report-error "ERROR: The input was not a .rar, .zip, .tar.gz or .tgz"
 
-        elif [[ "${name}" == *.tgz ]] || [[ "${name}" == *.tar.gz ]]; then
-
-          dx cat "${run_archive[${i}]}" | tar zxf - --no-same-owner
-
-        else
-
-          dx-jobutil-report-error "ERROR: The input was not a .rar, .zip, .tar.gz or .tgz"
-
-        fi
-done
-
-elif [ -n "${upload_sentinel_record}" ]
-  then
-  mkdir ./input
-  # get the tar.gzs linked to the record and uncompress them in the order they were created
-  file_ids=$(dx get_details "${upload_sentinel_record}" | jq -r '.tar_file_ids | .[]')
-
-  # This has to be done in order, so no parallelization
-
-  #Tarball are not in the correct order
-  declare -A files_names_ids
-
-  for id in $(echo ${file_ids}); do name=$(dx describe ${id} --name); files_names_ids[${name}]=${id}; echo ${name} >> files_names.tmp; done
-  sort files_names.tmp > files_names.txt
-
-  for name in $(cat files_names.txt); do
-    # format check and uncompress
-    file_id=${files_names_ids[${name}]}
-    extn="${name##*.}"
-
-    if [[ "${extn}" == "gz" ]]; then
-      dx cat ${file_id} | tar xzf - --no-same-owner -C ./input/
-
-    elif [[ "${extn}" == "tar" ]]; then
-      dx cat ${file_id} | tar xf - --no-same-owner -C ./input/
-
-    else
-        dx-jobutil-report-error "The upload_sentinel_record doesn't contain tar or tar.gzs"
-    fi
-
-  done
-  rm files_names.t*
-
-else
-  dx-jobutil-report-error "Please provide either a compressed RUN folder or an upload Sentinel Record as an input"
-fi
-
-# check for the presence/location of the run folder
-
-location_of_data=$(find . -type d -name "Data")
-
-if [ "${location_of_data}" == "" ]; then
-  dx-jobutil-report-error "The Data folder could not be found."
-fi
-
-location_of_runarchive=${location_of_data%/Data}
-
-# check if the samplesheet is provided as an input, if so, download it
-
-if [ "${sample_sheet}" != "" ]; then
-  dx download -f "${sample_sheet}" -o SampleSheet.csv
-
-
-# if not check if its present along with the sentinel record
-  # get the samplesheet id from the sentinel record and download it
-
-elif [ -n "${upload_sentinel_record}" ]; then
-  sample_sheet_id=$(dx get_details "${upload_sentinel_record}" | jq -r .samplesheet_file_id)
-
-  if [ "${sample_sheet_id}" ==  "null"  ]; then
-    dx-jobutil-report-error "Samplesheet was not found." AppInternalError
-
-  else
-    dx download -f "${sample_sheet_id}" -o SampleSheet.csv
-  fi
-
-  # check if its present in the run folder --
-elif [ -f ${location_of_runarchive}/SampleSheet.csv ]; then
-      echo "The SampleSheet found in the run directory."
-
-else
-      dx-jobutil-report-error "The SampleSheet could not be found."
-fi
-
-# make sure the sample sheet is present in the correct location as the tool would expect
-if [ "${location_of_runarchive}" != "." ]; then
-  mv SampleSheet.csv "${location_of_runarchive}"/SampleSheet.csv
-fi
-
-cd "${location_of_runarchive}"
-
-# formatting check
-/usr/bin/dos2unix SampleSheet.csv
-
-cp SampleSheet.csv SampleSheet.tmp
-
-# remove any non alphanumeric characters in place
-sed -i 's/[: ()]//g' SampleSheet.csv
-
-# get run ID for prefix the summary/stats files
-run_id=$(cat RunInfo.xml | grep "Run Id" | cut -d'"' -f2)
-
-
-docker load -i /bcl2fastq.tar.gz
-
-docker run --rm -v $PWD:/home/dnanexus/"${location_of_runarchive}" -w /home/dnanexus/"${location_of_runarchive}" bcl2fastq bcl2fastq $args $advanced_opts
-
-# /usr/bin/bcl2fastq $args $advanced_opts
-    
-  # Annotating R1 reads
-
-    awk -v value="Sample_ID" '{if($0~value) print $0",R1.fastq.gz"; else print $0}' SampleSheet.tmp > SampleSheet.csv
-  find . -name "*_R1_*.fastq.gz" -mindepth 5 | while read file
-  do 
-        prefix=`basename $file |  cut -d  '_' -f1`
-            if [ "$prefix" == "Undetermined" ]; then
-              echo "Don't test undetermined"
-          else
-          #prefix=`echo $file | cut -d '/' -f7 |  cut -d  '_' -f1`
-              size=$(stat -c%s "$file")
-            cp SampleSheet.csv SampleSheet.tmp
-          if [ "$size" -lt "$size_limit" ]; then
-                awk -v value="$prefix" '{if($0~value) print $0",FAIL"; else print $0}' SampleSheet.tmp >  SampleSheet.csv
-                else
-                  awk -v value="$prefix" '{if($0~value) print $0",PASS"; else print $0}' SampleSheet.tmp > SampleSheet.csv
-          fi
-    fi
-done
-
-# Annotating R2 reads
-    # cp SampleSheet.csv SampleSheet.tmp
-    awk -v value="Sample_ID" '{if($0~value) print $0",R2.fastq.gz"; else print $0}' SampleSheet.tmp > SampleSheet.csv
-    find . -name "*_R2_*.fastq.gz" -mindepth 5 | while read file
-  do
-        prefix=`basename $file | cut -d  '_' -f1`
-        if [ "$prefix" == "Undetermined" ]; then
-                              echo "Don't test undetermined"
-            else
-                  #prefix=`echo $file | cut -d '/' -f7 |  cut -d  '_' -f1`
-                  size=$(stat -c%s "$file")
-                # cp SampleSheet.csv SampleSheet.tmp
-                if [ "$size" -lt "$size_limit" ]; then
-                  awk -v value="$prefix" '{if($0~value) print $0",FAIL"; else print $0}' SampleSheet.tmp >  SampleSheet.csv
-                else
-                        awk -v value="$prefix" '{if($0~value) print $0",PASS"; else print $0}' SampleSheet.tmp > SampleSheet.csv
-                fi
-        fi
+      fi
     done
 
-dos2unix SampleSheet.csv
-cp SampleSheet.csv ${info}_SampleSheet.csv
+  elif [ -n "${upload_sentinel_record}" ]; then
+    mkdir ./input
+    # get the tar.gzs linked to the record and uncompress them in the order they were created
+    file_ids=$(dx get_details "${upload_sentinel_record}" | jq -r '.tar_file_ids | .[]')
 
+    # This has to be done in order, so no parallelization
 
-basecalls="Data/Intensities/BaseCalls/"
+    #Tarball are not in the correct order
+    declare -A files_names_ids
 
+    for id in $(echo ${file_ids}); do name=$(dx describe ${id} --name); files_names_ids[${name}]=${id}; echo ${name} >> files_names.tmp; done
+    sort files_names.tmp > files_names.txt
 
-#upload fastqs
-# Make a dummy entry for reads2 (for single end sequencing)
-echo "{\"reads2\":[]}" > ~/job_output.json
+    for name in $(cat files_names.txt); do
+      # format check and uncompress
+      file_id=${files_names_ids[${name}]}
+      extn="${name##*.}"
 
-  dx upload ${info}_SampleSheet.csv  --path $dest_project:/ 
-  
-  dx-jobutil-add-output out_info "$info" --class=string
-  file_id=$(dx upload SampleSheet.csv --brief)
-  dx-jobutil-add-output new_sample_sheet "$file_id" --class file
+      if [[ "${extn}" == "gz" ]]; then
+        dx cat ${file_id} | tar xzf - --no-same-owner -C ./input/
 
-# look for R1 fastq files and upload them
-find . -name "*_R1_*.fastq.gz" | while read fastq1
-do
+      elif [[ "${extn}" == "tar" ]]; then
+        dx cat ${file_id} | tar xf - --no-same-owner -C ./input/
 
-  name="${fastq1##./Data/Intensities/BaseCalls/}"
+      else
+          dx-jobutil-report-error "The upload_sentinel_record doesn't contain tar or tar.gzs"
+      fi
 
-  file_id=$(dx upload "${fastq1}" --brief -p --path "${name}")
-  dx-jobutil-add-output reads "${file_id}" --class file --array
+    done
+    rm files_names.t*
 
-  if [ -n "${upload_sentinel_record}" ]; then
-  /usr/bin/propagate-user-meta "${upload_sentinel_record}" "${file_id}"
+  else
+    dx-jobutil-report-error "Please provide either a compressed RUN folder or an upload Sentinel Record as an input"
   fi
 
-done
+  echo "Step 2: locate Data folder and SampleSheet.csv"
+  # Locate the unpacked Data files 
+  # check for the presence/location of the run folder
+  location_of_data=$(find . -type d -name "Data")
 
-# look for R2 fastq files and upload them
-find . -name "*_R2_*.fastq.gz" | while read fastq2
-do
+  if [ "${location_of_data}" == "" ]; then
+    dx-jobutil-report-error "The Data folder could not be found."
+  fi
 
-  name="${fastq2##./Data/Intensities/BaseCalls/}"
+  location_of_runarchive=${location_of_data%/Data}
 
-  file_id=$(dx upload "${fastq2}" --brief -p --path "${name}")
-  dx-jobutil-add-output reads2 "${file_id}" --class file --array
+  # Find the SampleSheet.csv
+  # check if the samplesheet is provided as an input, if so, download it
+  if [ "${sample_sheet}" != "" ]; then
+    dx download -f "${sample_sheet}" -o SampleSheet.csv
 
-  if [ -n "${upload_sentinel_record}" ]; then
-  /usr/bin/propagate-user-meta "${upload_sentinel_record}" "${file_id}"
-fi
-done
+    # make sure the sample sheet is present in the correct location as the tool would expect
+    if [ "${location_of_runarchive}" != "." ]; then
+      mv SampleSheet.csv "${location_of_runarchive}"/SampleSheet.csv
+    fi
 
-#upload reports
-reportsbase="${basecalls}Reports/"
+  # if not, check if its present along with the sentinel record
+    # get the samplesheet id from the sentinel record and download it
+  # elif [ -n "${upload_sentinel_record}" ]; then
+  #   sample_sheet_id=$(dx get_details "${upload_sentinel_record}" | jq -r .samplesheet_file_id)
 
-# concatenate all the lane.html and laneBarcode.html files
-all_barcodes=''
-all_lanes=''
-for file in $(find ${reportsbase} -name "laneBarcode.html"); do all_barcodes="${all_barcodes} ${file}"; done
-cat ${all_barcodes} > all_barcodes.html
-cat all_barcodes.html | grep -v "hide" > all_barcodes_edited.html
+  #   if [ "${sample_sheet_id}" ==  "null"  ]; then
+  #     dx-jobutil-report-error "Samplesheet was not found." AppInternalError
+  #   else
+  #     dx download -f "${sample_sheet_id}" -o SampleSheet.csv
+  #   fi
 
-for file in $(find ${reportsbase} -name "lane.html"); do all_lanes="${all_lanes} ${file}"; done
-cat ${all_lanes} > all_lanes.html
-cat all_lanes.html | grep -v "show" > all_lanes_edited.html
+  # check if its present in the run folder
+  elif [ -f ${location_of_runarchive}/*heet.csv ]; then
+    mv ${location_of_runarchive}/*heet.csv "${location_of_runarchive}"/SampleSheet.csv
+    echo "The SampleSheet.csv was found in the run directory."
 
-# upload the html files
-file_id=$(dx upload all_barcodes_edited.html --brief -p --path "summary/${run_id}_all_barcodes.html")
-dx-jobutil-add-output stats "${file_id}" --class file --array
+  else
+      dx-jobutil-report-error "No SampleSheet could be found."
+  fi
 
-  if [ -n "${upload_sentinel_record}" ]; then
-  /usr/bin/propagate-user-meta "${upload_sentinel_record}" "${file_id}"
-fi
+  cd "${location_of_runarchive}"
 
-file_id=$(dx upload all_lanes_edited.html --brief -p --path "summary/${run_id}_all_lanes.html")
-dx-jobutil-add-output stats "${file_id}" --class file --array
+  # formatting check
+  # /usr/bin/dos2unix SampleSheet.csv
+  cp SampleSheet.csv SampleSheet.tmp
+  # remove any non alphanumeric characters in place
+  sed -i 's/[: ()]//g' SampleSheet.csv
 
-  if [ -n "${upload_sentinel_record}" ]; then
-  /usr/bin/propagate-user-meta "${upload_sentinel_record}" "${file_id}"
-fi
+  echo "Step 3: build and run bcl2fastq" # from asset
+  # Load the bcl2fastq from root where it was placed from the asset bundle
+  dpkg -i /bcl2fastq*.deb
 
-#upload stats
-statsbase="${basecalls}Stats/"
-find $statsbase -name "*.xml" | while read xml
-do
+  bcl2fastq $advanced_opts
+  # /usr/bin/bcl2fastq $advanced_opts
+      
+  # # Annotating R1 reads
+    awk -v value="Sample_ID" '{if($0~value) print $0",R1.fastq.gz"; else print $0}' SampleSheet.tmp > SampleSheet.csv
+    find . -name "*_R1_*.fastq.gz" -mindepth 5 | while read file
+      do 
+        prefix=`basename $file |  cut -d  '_' -f1`
+        if [ "$prefix" == "Undetermined" ]; then
+            echo "Don't test undetermined"
+        else
+        #prefix=`echo $file | cut -d '/' -f7 |  cut -d  '_' -f1`
+          size=$(stat -c%s "$file")
+          cp SampleSheet.csv SampleSheet.tmp
+          if [ "$size" -lt "$size_limit" ]; then
+            awk -v value="$prefix" '{if($0~value) print $0",FAIL"; else print $0}' SampleSheet.tmp >  SampleSheet.csv
+          else
+            awk -v value="$prefix" '{if($0~value) print $0",PASS"; else print $0}' SampleSheet.tmp > SampleSheet.csv
+          fi
+        fi
+      done
 
-  name="${xml##Data/Intensities/BaseCalls/Stats/}"
-  file_id=$(dx upload "${xml}" --brief -p --path "summary/${run_id}_${name}")
-  dx-jobutil-add-output stats "${file_id}" --class file --array
+  # # Annotating R2 reads
+    awk -v value="Sample_ID" '{if($0~value) print $0",R2.fastq.gz"; else print $0}' SampleSheet.tmp > SampleSheet.csv
+    find . -name "*_R2_*.fastq.gz" -mindepth 5 | while read file
+      do
+        prefix=`basename $file | cut -d  '_' -f1`
+        if [ "$prefix" == "Undetermined" ]; then
+          echo "Don't test undetermined"
+        else
+          #prefix=`echo $file | cut -d '/' -f7 |  cut -d  '_' -f1`
+          size=$(stat -c%s "$file")
+          cp SampleSheet.csv SampleSheet.tmp
+          if [ "$size" -lt "$size_limit" ]; then
+            awk -v value="$prefix" '{if($0~value) print $0",FAIL"; else print $0}' SampleSheet.tmp >  SampleSheet.csv
+          else
+            awk -v value="$prefix" '{if($0~value) print $0",PASS"; else print $0}' SampleSheet.tmp > SampleSheet.csv
+          fi
+        fi
+      done
 
-  if [ -n "${upload_sentinel_record}" ]; then
-  /usr/bin/propagate-user-meta "${upload_sentinel_record}" "${file_id}"
-fi
-done
+  # get run ID to prefix the summary and stats files
+  run_id=$(cat RunInfo.xml | grep "Run Id" | cut -d'"' -f2)
+  echo $run_id
 
-#upload summaries
-find ${statsbase} -name "FastqSummary*.txt" | while read summary
-do
+  # dos2unix SampleSheet.csv
+  cp SampleSheet.csv ${run_id}_SampleSheet.csv  
 
-  name="${summary##Data/Intensities/BaseCalls/Stats/}"
-  file_id=$(dx upload "${summary}" --brief -p --path "summary/${run_id}_${name}")
-  dx-jobutil-add-output fastq_summaries "${file_id}" --class file --array
+  echo "Step 4: upload fastqs and run statistics"
+  # look for R1 fastq files and upload them
+  out_reads=/home/dnanexus/out/fastqs && mkdir -p ${out_reads}
+  mkdir ${out_reads}/${run_id}_fastqs
+  mv ./Data/Intensities/BaseCalls/*.fastq.gz ${out_reads}/${run_id}_fastqs
 
-  if [ -n "${upload_sentinel_record}" ]; then
-  /usr/bin/propagate-user-meta "${upload_sentinel_record}" "${file_id}"
-fi
-done
+  # # Make a dummy entry for reads2 (for single end sequencing)
+  # echo "{\"reads2\":[]}" > ~/job_output.json
+  # # look for R2 fastq files and upload them
+  # out_reads2=out/reads2 && mkdir -p ${out_reads2}
+  # mkdir ${out_reads2}/fastqs
+  # mv ./Data/Intensities/BaseCalls/*_R2_*.fastq.gz ${out_reads2}/fastqs
 
-find ${statsbase} -name "DemuxSummary*.txt" | while read summary
-do
-  name="${summary##Data/Intensities/BaseCalls/Stats*/}"
-  file_id=$(dx upload "${summary}" --brief -p --path "summary/${run_id}_${name}")
-  dx-jobutil-add-output demux_summaries "${file_id}" --class file --array
+  # upload reports (stats)
+  out_stats=/home/dnanexus/out/stats/${run_id}_stats && mkdir -p ${out_stats}
+  mkdir ${out_stats}/Data_Intensities_BaseCalls_Stats
+  mv RunInfo.xml ${out_stats}/
+  mv ${run_id}_SampleSheet.csv ${out_stats}/
+  mv ./Data/Intensities/BaseCalls/Stats/* ${out_stats}/Data_Intensities_BaseCalls_Stats/
 
-  if [ -n "${upload_sentinel_record}" ]; then
-  /usr/bin/propagate-user-meta "${upload_sentinel_record}" "${file_id}"
-fi
-done
+  # concatenate all the lane.html and laneBarcode.html files
+  all_barcodes=''
+  for file in $(find Data/Intensities/BaseCalls/Reports/ -name "laneBarcode.html"); do all_barcodes="${all_barcodes} ${file}"; done
+  cat ${all_barcodes} > all_barcodes.html
+  cat all_barcodes.html | grep -v "hide" > all_barcodes_edited.html
+  mv all_barcodes_edited.html ${out_stats}/${run_id}_all_barcodes.html
 
-record_id=$(create_stat_summary.py --fastq_summaries $(find "${statsbase}" -name "FastqSummary*.txt") \
-    --demux_summaries $(find "${statsbase}" -name "DemuxSummary*.txt") \
-    --record_name "${run_id}".stats_record)
+  all_lanes=''
+  for file in $(find Data/Intensities/BaseCalls/Reports/ -name "lane.html"); do all_lanes="${all_lanes} ${file}"; done
+  cat ${all_lanes} > all_lanes.html
+  cat all_lanes.html | grep -v "show" > all_lanes_edited.html
+  mv all_lanes_edited.html ${out_stats}/${run_id}_all_lanes.html
 
-dx-jobutil-add-output stats_record "${record_id}" --class record
+  mkdir ${out_stats}/Config
+  mv ./Config/* ${out_stats}/Config
 
-if [ -n "${upload_sentinel_record}" ]; then
-/usr/bin/propagate-user-meta "${upload_sentinel_record}" "${record_id}"
-fi
+  mkdir ${out_stats}/Recipe
+  mv ./Recipe/* ${out_stats}/Recipe
+
+  mkdir ${out_stats}/Logs
+  mv ./Logs/* ${out_stats}/Logs
+
+  mkdir ${out_stats}/InterOp
+  mv ./InterOp/* ${out_stats}/InterOp
+
+  mv ./R*.* ${out_stats}/
+
+  ls
+  ls /home/dnanexus/out/
+  # Upload outputs
+  dx-upload-all-outputs
+
+  echo "DONE!"
+}

--- a/src/code.sh
+++ b/src/code.sh
@@ -1,0 +1,300 @@
+#!/bin/bash
+
+# The following line causes bash to exit at any point if there is any error
+# and to output each line as it is executed -- useful for debugging
+set -e -x -o pipefail
+
+# check if lane splitting is turned on
+if [ "${no_lane_splitting}" == "true" ]
+then
+    args+=("--no-lane-splitting")
+fi
+
+ # either a run archive or a sentinel record must be provided as an input
+  if [ -n "${run_archive}" ]; then
+
+    for i in ${!run_archive_name[@]}; do
+
+        # format check and uncompress
+        name="${run_archive_name[${i}]}"
+        if [ "${name}" == *.rar ]; then
+
+          dx download "${run_archive[${i}]}" -o "${name}"
+          unrar x "${name}"
+
+        elif [ "${name}" == *.zip ]; then
+
+          dx download "${run_archive[$i]}" -o "${name}"
+          unzip "${name}"
+
+        elif [[ "${name}" == *.tgz ]] || [[ "${name}" == *.tar.gz ]]; then
+
+          dx cat "${run_archive[${i}]}" | tar zxf - --no-same-owner
+
+        else
+
+          dx-jobutil-report-error "ERROR: The input was not a .rar, .zip, .tar.gz or .tgz"
+
+        fi
+done
+
+elif [ -n "${upload_sentinel_record}" ]
+  then
+  mkdir ./input
+  # get the tar.gzs linked to the record and uncompress them in the order they were created
+  file_ids=$(dx get_details "${upload_sentinel_record}" | jq -r '.tar_file_ids | .[]')
+
+  # This has to be done in order, so no parallelization
+
+  #Tarball are not in the correct order
+  declare -A files_names_ids
+
+  for id in $(echo ${file_ids}); do name=$(dx describe ${id} --name); files_names_ids[${name}]=${id}; echo ${name} >> files_names.tmp; done
+  sort files_names.tmp > files_names.txt
+
+  for name in $(cat files_names.txt); do
+    # format check and uncompress
+    file_id=${files_names_ids[${name}]}
+    extn="${name##*.}"
+
+    if [[ "${extn}" == "gz" ]]; then
+      dx cat ${file_id} | tar xzf - --no-same-owner -C ./input/
+
+    elif [[ "${extn}" == "tar" ]]; then
+      dx cat ${file_id} | tar xf - --no-same-owner -C ./input/
+
+    else
+        dx-jobutil-report-error "The upload_sentinel_record doesn't contain tar or tar.gzs"
+    fi
+
+  done
+  rm files_names.t*
+
+else
+  dx-jobutil-report-error "Please provide either a compressed RUN folder or an upload Sentinel Record as an input"
+fi
+
+# check for the presence/location of the run folder
+
+location_of_data=$(find . -type d -name "Data")
+
+if [ "${location_of_data}" == "" ]; then
+  dx-jobutil-report-error "The Data folder could not be found."
+fi
+
+location_of_runarchive=${location_of_data%/Data}
+
+# check if the samplesheet is provided as an input, if so, download it
+
+if [ "${sample_sheet}" != "" ]; then
+  dx download -f "${sample_sheet}" -o SampleSheet.csv
+
+
+# if not check if its present along with the sentinel record
+  # get the samplesheet id from the sentinel record and download it
+
+elif [ -n "${upload_sentinel_record}" ]; then
+  sample_sheet_id=$(dx get_details "${upload_sentinel_record}" | jq -r .samplesheet_file_id)
+
+  if [ "${sample_sheet_id}" ==  "null"  ]; then
+    dx-jobutil-report-error "Samplesheet was not found." AppInternalError
+
+  else
+    dx download -f "${sample_sheet_id}" -o SampleSheet.csv
+  fi
+
+  # check if its present in the run folder --
+elif [ -f ${location_of_runarchive}/SampleSheet.csv ]; then
+      echo "The SampleSheet found in the run directory."
+
+else
+      dx-jobutil-report-error "The SampleSheet could not be found."
+fi
+
+# make sure the sample sheet is present in the correct location as the tool would expect
+if [ "${location_of_runarchive}" != "." ]; then
+  mv SampleSheet.csv "${location_of_runarchive}"/SampleSheet.csv
+fi
+
+cd "${location_of_runarchive}"
+
+# formatting check
+/usr/bin/dos2unix SampleSheet.csv
+
+cp SampleSheet.csv SampleSheet.tmp
+
+# remove any non alphanumeric characters in place
+sed -i 's/[: ()]//g' SampleSheet.csv
+
+# get run ID for prefix the summary/stats files
+run_id=$(cat RunInfo.xml | grep "Run Id" | cut -d'"' -f2)
+
+
+docker load -i /bcl2fastq.tar.gz
+
+docker run --rm -v $PWD:/home/dnanexus/"${location_of_runarchive}" -w /home/dnanexus/"${location_of_runarchive}" bcl2fastq bcl2fastq $args $advanced_opts
+
+# /usr/bin/bcl2fastq $args $advanced_opts
+    
+  # Annotating R1 reads
+
+    awk -v value="Sample_ID" '{if($0~value) print $0",R1.fastq.gz"; else print $0}' SampleSheet.tmp > SampleSheet.csv
+  find . -name "*_R1_*.fastq.gz" -mindepth 5 | while read file
+  do 
+        prefix=`basename $file |  cut -d  '_' -f1`
+            if [ "$prefix" == "Undetermined" ]; then
+              echo "Don't test undetermined"
+          else
+          #prefix=`echo $file | cut -d '/' -f7 |  cut -d  '_' -f1`
+              size=$(stat -c%s "$file")
+            cp SampleSheet.csv SampleSheet.tmp
+          if [ "$size" -lt "$size_limit" ]; then
+                awk -v value="$prefix" '{if($0~value) print $0",FAIL"; else print $0}' SampleSheet.tmp >  SampleSheet.csv
+                else
+                  awk -v value="$prefix" '{if($0~value) print $0",PASS"; else print $0}' SampleSheet.tmp > SampleSheet.csv
+          fi
+    fi
+done
+
+# Annotating R2 reads
+    # cp SampleSheet.csv SampleSheet.tmp
+    awk -v value="Sample_ID" '{if($0~value) print $0",R2.fastq.gz"; else print $0}' SampleSheet.tmp > SampleSheet.csv
+    find . -name "*_R2_*.fastq.gz" -mindepth 5 | while read file
+  do
+        prefix=`basename $file | cut -d  '_' -f1`
+        if [ "$prefix" == "Undetermined" ]; then
+                              echo "Don't test undetermined"
+            else
+                  #prefix=`echo $file | cut -d '/' -f7 |  cut -d  '_' -f1`
+                  size=$(stat -c%s "$file")
+                # cp SampleSheet.csv SampleSheet.tmp
+                if [ "$size" -lt "$size_limit" ]; then
+                  awk -v value="$prefix" '{if($0~value) print $0",FAIL"; else print $0}' SampleSheet.tmp >  SampleSheet.csv
+                else
+                        awk -v value="$prefix" '{if($0~value) print $0",PASS"; else print $0}' SampleSheet.tmp > SampleSheet.csv
+                fi
+        fi
+    done
+
+dos2unix SampleSheet.csv
+cp SampleSheet.csv ${info}_SampleSheet.csv
+
+
+basecalls="Data/Intensities/BaseCalls/"
+
+
+#upload fastqs
+# Make a dummy entry for reads2 (for single end sequencing)
+echo "{\"reads2\":[]}" > ~/job_output.json
+
+  dx upload ${info}_SampleSheet.csv  --path $dest_project:/ 
+  
+  dx-jobutil-add-output out_info "$info" --class=string
+  file_id=$(dx upload SampleSheet.csv --brief)
+  dx-jobutil-add-output new_sample_sheet "$file_id" --class file
+
+# look for R1 fastq files and upload them
+find . -name "*_R1_*.fastq.gz" | while read fastq1
+do
+
+  name="${fastq1##./Data/Intensities/BaseCalls/}"
+
+  file_id=$(dx upload "${fastq1}" --brief -p --path "${name}")
+  dx-jobutil-add-output reads "${file_id}" --class file --array
+
+  if [ -n "${upload_sentinel_record}" ]; then
+  /usr/bin/propagate-user-meta "${upload_sentinel_record}" "${file_id}"
+  fi
+
+done
+
+# look for R2 fastq files and upload them
+find . -name "*_R2_*.fastq.gz" | while read fastq2
+do
+
+  name="${fastq2##./Data/Intensities/BaseCalls/}"
+
+  file_id=$(dx upload "${fastq2}" --brief -p --path "${name}")
+  dx-jobutil-add-output reads2 "${file_id}" --class file --array
+
+  if [ -n "${upload_sentinel_record}" ]; then
+  /usr/bin/propagate-user-meta "${upload_sentinel_record}" "${file_id}"
+fi
+done
+
+#upload reports
+reportsbase="${basecalls}Reports/"
+
+# concatenate all the lane.html and laneBarcode.html files
+all_barcodes=''
+all_lanes=''
+for file in $(find ${reportsbase} -name "laneBarcode.html"); do all_barcodes="${all_barcodes} ${file}"; done
+cat ${all_barcodes} > all_barcodes.html
+cat all_barcodes.html | grep -v "hide" > all_barcodes_edited.html
+
+for file in $(find ${reportsbase} -name "lane.html"); do all_lanes="${all_lanes} ${file}"; done
+cat ${all_lanes} > all_lanes.html
+cat all_lanes.html | grep -v "show" > all_lanes_edited.html
+
+# upload the html files
+file_id=$(dx upload all_barcodes_edited.html --brief -p --path "summary/${run_id}_all_barcodes.html")
+dx-jobutil-add-output stats "${file_id}" --class file --array
+
+  if [ -n "${upload_sentinel_record}" ]; then
+  /usr/bin/propagate-user-meta "${upload_sentinel_record}" "${file_id}"
+fi
+
+file_id=$(dx upload all_lanes_edited.html --brief -p --path "summary/${run_id}_all_lanes.html")
+dx-jobutil-add-output stats "${file_id}" --class file --array
+
+  if [ -n "${upload_sentinel_record}" ]; then
+  /usr/bin/propagate-user-meta "${upload_sentinel_record}" "${file_id}"
+fi
+
+#upload stats
+statsbase="${basecalls}Stats/"
+find $statsbase -name "*.xml" | while read xml
+do
+
+  name="${xml##Data/Intensities/BaseCalls/Stats/}"
+  file_id=$(dx upload "${xml}" --brief -p --path "summary/${run_id}_${name}")
+  dx-jobutil-add-output stats "${file_id}" --class file --array
+
+  if [ -n "${upload_sentinel_record}" ]; then
+  /usr/bin/propagate-user-meta "${upload_sentinel_record}" "${file_id}"
+fi
+done
+
+#upload summaries
+find ${statsbase} -name "FastqSummary*.txt" | while read summary
+do
+
+  name="${summary##Data/Intensities/BaseCalls/Stats/}"
+  file_id=$(dx upload "${summary}" --brief -p --path "summary/${run_id}_${name}")
+  dx-jobutil-add-output fastq_summaries "${file_id}" --class file --array
+
+  if [ -n "${upload_sentinel_record}" ]; then
+  /usr/bin/propagate-user-meta "${upload_sentinel_record}" "${file_id}"
+fi
+done
+
+find ${statsbase} -name "DemuxSummary*.txt" | while read summary
+do
+  name="${summary##Data/Intensities/BaseCalls/Stats*/}"
+  file_id=$(dx upload "${summary}" --brief -p --path "summary/${run_id}_${name}")
+  dx-jobutil-add-output demux_summaries "${file_id}" --class file --array
+
+  if [ -n "${upload_sentinel_record}" ]; then
+  /usr/bin/propagate-user-meta "${upload_sentinel_record}" "${file_id}"
+fi
+done
+
+record_id=$(create_stat_summary.py --fastq_summaries $(find "${statsbase}" -name "FastqSummary*.txt") \
+    --demux_summaries $(find "${statsbase}" -name "DemuxSummary*.txt") \
+    --record_name "${run_id}".stats_record)
+
+dx-jobutil-add-output stats_record "${record_id}" --class record
+
+if [ -n "${upload_sentinel_record}" ]; then
+/usr/bin/propagate-user-meta "${upload_sentinel_record}" "${record_id}"
+fi


### PR DESCRIPTION
DNAnexus applet using the Illumina bcl2fastq software version 2.20 from an asset stored in 001.
Can be run with input of a single sentinel record file (that gets generated by dx-streaming-upload) or an array of tar.gz packets as a result of uploading data from a (NovaSeq) sequencer using https://github.com/eastgenomics/dx-streaming-upload.
Optionally a SampleSheet.csv can be provided, which will overwrite the one from the sequencer (which may have incorrect sample naming or not exist, as it is no longer essential for sequencing).
The data from the sequencer is unpacked and the bcl files are demultiplexed by bcl2fastq with information from the SampleSheet.csv (correct naming and use of the correct barcode sequences in the SampleSheet is essential!!)
The applet then outputs the fastq files and stats from demultiplexing (Stats.json) as well as sequencing log files, mirroring the directory structure on the sequencer.
Example of the job output from the current applet version can be found [here](https://platform.dnanexus.com/projects/G1gbJ3048k0yzP545gppfVgV/monitor/job/G28Y6Y848k0QbF8FBPjq261Z)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_bcl2fastq/1)
<!-- Reviewable:end -->
