### PR TITLE
Inter op branch

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -1,7 +1,7 @@
 {
-  "name": "eggd_bcl2fastq2.20",
+  "name": "eggd_bcl2fastq",
   "title": "BCL to FASTQ v2.20",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "summary": "Converts Illumina data from BCL to FASTQ using bcl2fastq v2.20 demultiplexing barcoded samples, for use with NextSeq, HiSeq, NovaSeq",
   "tags": ["Read Mapping"],
   "dxapi": "1.0.0",
@@ -53,6 +53,11 @@
     "version": "0",
     "interpreter": "bash",
     "distribution": "Ubuntu",
+    "timeoutPolicy": {
+      "*": {
+        "hours": 18
+      }
+    },
     "assetDepends": [
       {
         "name": "bcl2fastq",

--- a/src/code.sh
+++ b/src/code.sh
@@ -154,6 +154,13 @@ main() {
   mkdir bcls
   mv Data/Intensities/BaseCalls/L* bcls/
 
+  # Process InterOp files to produce inputs to multiqc, send them to output
+  tar -xvjf ~/illumina-interop-1.5.0-h503566f_0.tar.bz2 -C interop_pkg
+  export PATH="$PWD/interop_pkg/bin:$PATH"
+  echo "Generating InterOp summary CSV files"
+  interop_summary --csv=1 InterOp/ > ${outdir}/interop_summary.csv || echo "interop_summary failed"
+  interop_index-summary --csv=1 InterOp/ > ${outdir}/interop_index_summary.csv || echo "interop_index-summary failed"
+  
   # tar the Logs/ and InterOp/ directories to speed up upload process
   tar -czf InterOp.tar.gz InterOp/
   tar -czf Logs.tar.gz Logs/


### PR DESCRIPTION
Selected a timout policy of 18 hours based on the longest execution time of BCL2FASTQ being 12h 45min, the default time out for DNAnexus being 48h and the 12h timeout policy of TSO500.

Changed the name to not contain the version.

Updated the version to 1.3.0.

Included illumina interop package and the code to process interop and produce the outputs for multiqc.