### PR TITLE
Inter op branch

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -49,7 +49,7 @@
   ],
   "runSpec": {
     "file": "src/code.sh",
-    "release": "20.04",
+    "release": "24.04",
     "version": "0",
     "interpreter": "bash",
     "distribution": "Ubuntu",

--- a/src/code.sh
+++ b/src/code.sh
@@ -14,10 +14,6 @@ kill $(ps aux | grep pcp-dstat | head -n1 | awk '{print $2}')
 main() {
 
   echo "Step 1: download input tars and unpack them"
-  # untar InterOp tarball be be able to run interop commands
-  mkdir -p interop_pkg
-  tar -xvjf ~/illumina-interop-1.4.0-h503566f_0.tar.bz2 -C interop_pkg
-  export PATH="$PWD/interop_pkg/bin:$PATH"
 
   # either a run archive or a sentinel record must be provided as an input
   if [ -n "${run_archive}" ]; then
@@ -165,7 +161,13 @@ main() {
   # remove bcl files and their folders
   mkdir bcls
   mv Data/Intensities/BaseCalls/L* bcls/
+
+  # untar InterOp tarball be be able to run interop commands
   echo "Generating InterOp summary CSV files"
+  mkdir -p interop_pkg
+  tar -xvjf ~/illumina-interop-1.5.0-h503566f_0.tar.bz2 -C interop_pkg
+  export PATH="$PWD/interop_pkg/bin:$PATH"
+  # Run InterOp commands
   interop_summary --csv=1 ~/ > ${outdir}/interop_summary.csv || echo "interop_summary failed"
   interop_index-summary --csv=1 ~/ > ${outdir}/interop_index_summary.csv || echo "interop_index-summary failed"
 

--- a/src/code.sh
+++ b/src/code.sh
@@ -168,7 +168,7 @@ main() {
   echo "Generating InterOp summary CSV files"
   interop_summary --csv=1 ~/ > ${outdir}/interop_summary.csv || echo "interop_summary failed"
   interop_index-summary --csv=1 ~/ > ${outdir}/interop_index_summary.csv || echo "interop_index-summary failed"
-  
+
   # tar the Logs/ and InterOp/ directories to speed up upload process
   tar -czf InterOp.tar.gz InterOp/
   tar -czf Logs.tar.gz Logs/


### PR DESCRIPTION
Fixes #16 and #17 

1. Changes app name in the dxapp.json to eggd_bcl2fastq.
2. Time out has already been added.
3. Updated ubuntu to 24.04
4. Updated version to 1.3.0
5. prefixes all lines of commands written to stdout with datetime
6. Uses InterOp 1.4 tarball
7. Set frequency of instance usage in logs to 10 seconds
8. Corrects Path for InterOp

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_bcl2fastq/20)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the Ubuntu version used for execution from 20.04 to 24.04.

- **Enhancements**
	- Improved command logging with timestamped output.
	- Enhanced monitoring by restarting system usage tracking with a 10-second interval.
	- Updated handling of Illumina InterOp tools to version 1.5.0 and adjusted summary command execution location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->